### PR TITLE
Ambiguous method reference is not highlighted when static and non-static methods in match

### DIFF
--- a/java/java-psi-impl/src/com/intellij/psi/impl/source/tree/java/MethodReferenceResolver.java
+++ b/java/java-psi-impl/src/com/intellij/psi/impl/source/tree/java/MethodReferenceResolver.java
@@ -235,12 +235,21 @@ public class MethodReferenceResolver implements ResolveCache.PolyVariantContextR
 
       List<CandidateInfo> firstCandidates = new ArrayList<>();
       List<CandidateInfo> secondCandidates = new ArrayList<>();
+      boolean thereIsStaticInTheFirst = false;
+      boolean thereIsNonStaticInTheSecond = false;
 
       for (CandidateInfo conflict : conflicts) {
         if (!(conflict instanceof MethodCandidateInfo)) continue;
         Boolean applicableByFirstSearch = isApplicableByFirstSearch(conflict, argTypes, hasReceiver, myReferenceExpression, myFunctionalMethodVarArgs, myInterfaceMethod);
         if (applicableByFirstSearch != null) {
           (applicableByFirstSearch ? firstCandidates : secondCandidates).add(conflict);
+          boolean isStatic = isStaticMethod(conflict);
+          if (isStatic && applicableByFirstSearch) {
+            thereIsStaticInTheFirst = true;
+          }
+          if (!isStatic && !applicableByFirstSearch) {
+            thereIsNonStaticInTheSecond = true;
+          }
         }
       }
 
@@ -259,11 +268,13 @@ public class MethodReferenceResolver implements ResolveCache.PolyVariantContextR
       }
 
       CandidateInfo candidateInfo = resolveConflicts(firstCandidates, secondCandidates, map, MethodCandidateInfo.ApplicabilityLevel.FIXED_ARITY);
+      candidateInfo = checkStaticNonStaticConflict(candidateInfo, firstCandidates, secondCandidates, thereIsStaticInTheFirst, thereIsNonStaticInTheSecond);
       if (candidateInfo != null) {
         return candidateInfo;
       }
 
       candidateInfo = resolveConflicts(firstCandidates, secondCandidates, map, MethodCandidateInfo.ApplicabilityLevel.VARARGS);
+      candidateInfo = checkStaticNonStaticConflict(candidateInfo, firstCandidates, secondCandidates, thereIsStaticInTheFirst, thereIsNonStaticInTheSecond);
       if (candidateInfo != null) {
         return candidateInfo;
       }
@@ -276,6 +287,28 @@ public class MethodReferenceResolver implements ResolveCache.PolyVariantContextR
       firstCandidates.addAll(secondCandidates);
       conflicts.addAll(firstCandidates);
       return null;
+    }
+
+    private CandidateInfo checkStaticNonStaticConflict(CandidateInfo candidateInfo,
+                                                       @NotNull List<CandidateInfo> firstCandidates,
+                                                       @NotNull List<CandidateInfo> secondCandidates,
+                                                       boolean thereIsStaticInTheFirst,
+                                                       boolean thereIsNonStaticInTheSecond) {
+      if (candidateInfo == null ||
+          !myQualifierResolveResult.isReferenceTypeQualified() ||
+          !(myReferenceExpression.getReferenceNameElement() instanceof PsiIdentifier)) {
+        return candidateInfo;
+      }
+      boolean isStatic = isStaticMethod(candidateInfo);
+      if (isStatic && !thereIsNonStaticInTheSecond && firstCandidates.contains(candidateInfo) ||
+          !isStatic && !thereIsStaticInTheFirst && secondCandidates.contains(candidateInfo)) {
+        return candidateInfo;
+      }
+      return null;
+    }
+
+    private static boolean isStaticMethod(@NotNull CandidateInfo candidateInfo) {
+      return ((MethodCandidateInfo) candidateInfo).getElement().hasModifierProperty(PsiModifier.STATIC);
     }
 
     private static Boolean isApplicableByFirstSearch(@NotNull CandidateInfo conflict,
@@ -307,6 +340,9 @@ public class MethodReferenceResolver implements ResolveCache.PolyVariantContextR
               return null;
             }
           }
+        } else if (hasReceiver && varargs &&
+                   isCorrectAssignment(parameterTypes, functionalInterfaceParamTypes, interfaceMethod, true, conflict, 1)) {
+          return false;
         }
         return true;
       }

--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/AaaConfusingErrorMessageWhileIncompatibleTypes.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/AaaConfusingErrorMessageWhileIncompatibleTypes.java
@@ -1,0 +1,12 @@
+class Test {
+
+  static void m(Test t, Test... ts) {}
+
+  interface I {
+    void m(Test... t);
+  }
+
+  static void test() {
+    I i = Test::<error descr="Incompatible types: Test[] is not convertible to Test">m</error>;
+  }
+}

--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/AaaInstanceInstance.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/AaaInstanceInstance.java
@@ -1,0 +1,14 @@
+class Test {
+  static class A {
+    void foo() {int i = 1;}
+    void foo(A a) {double j = 2;}
+  }
+
+  interface I {
+    void bar(A a);
+  }
+
+  static void test() {
+    I i = A::foo;
+  }
+}

--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/AaaInstanceInstanceVararg.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/AaaInstanceInstanceVararg.java
@@ -1,0 +1,14 @@
+class Test {
+  static class A {
+    void foo() {int i = 1;}
+    void foo(A... as) {double j = 2;}
+  }
+
+  interface I {
+    void bar(A a);
+  }
+
+  static void test() {
+    I i = A::foo;
+  }
+}

--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/AaaInstanceStatic.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/AaaInstanceStatic.java
@@ -1,0 +1,14 @@
+class Test {
+  static class A {
+    void foo() {int i = 1;}
+    static void foo(A a) {double j = 2;}
+  }
+
+  interface I {
+    void bar(A a);
+  }
+
+  static void test() {
+    I i = A::<error descr="Reference to 'foo' is ambiguous, both 'foo(A)' and 'foo()' match">foo</error>;
+  }
+}

--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/AaaInstanceStaticVararg.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/AaaInstanceStaticVararg.java
@@ -1,0 +1,14 @@
+class Test {
+  static class A {
+    void foo() {int i = 1;}
+    static void foo(A a, A... as) {double j = 2;}
+  }
+
+  interface I {
+    void bar(A a);
+  }
+
+  static void test() {
+    I i = A::<error descr="Reference to 'foo' is ambiguous, both 'foo(A, A...)' and 'foo()' match">foo</error>;
+  }
+}

--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/AaaInstanceVarargStatic.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/AaaInstanceVarargStatic.java
@@ -1,0 +1,14 @@
+class Test {
+  static class A {
+    void foo(A... as) {int i = 1;}
+    static void foo(A a) {double j = 2;}
+  }
+
+  interface I {
+    void bar(A a);
+  }
+
+  static void test() {
+    I i = A::<error descr="Reference to 'foo' is ambiguous, both 'foo(A)' and 'foo(A...)' match">foo</error>;
+  }
+}

--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/AaaInstanceVarargStaticVararg.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/AaaInstanceVarargStaticVararg.java
@@ -1,0 +1,14 @@
+class Test {
+  static class A {
+    void foo(A... as) {int i = 1;}
+    static void foo(A a, A... as) {double j = 2;}
+  }
+
+  interface I {
+    void bar(A a);
+  }
+
+  static void test() {
+    I i = A::<error descr="Reference to 'foo' is ambiguous, both 'foo(A, A...)' and 'foo(A...)' match">foo</error>;
+  }
+}

--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/AaaStaticStaticVararg.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/AaaStaticStaticVararg.java
@@ -1,0 +1,14 @@
+class Test {
+  static class A {
+    static void foo(A a) {int i = 1;}
+    static void foo(A a, A... as) {double j = 2;}
+  }
+
+  interface I {
+    void bar(A a);
+  }
+
+  static void test() {
+    I i = A::foo;
+  }
+}

--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/StaticNonStaticWithVarargsReferenceTypeAmbiguity.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/StaticNonStaticWithVarargsReferenceTypeAmbiguity.java
@@ -1,0 +1,15 @@
+class Test {
+
+  static class A {
+    void foo(A... as) {}
+    static void foo(A a) {}
+  }
+
+  interface I {
+    void bar(A a);
+  }
+
+  static void test() {
+    I i = A::<error descr="Reference to 'foo' is ambiguous, both 'foo(A)' and 'foo(A...)' match">foo</error>;
+  }
+}

--- a/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/StaticWithVarargsNonStaticReferenceTypeAmbiguity.java
+++ b/java/java-tests/testData/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/StaticWithVarargsNonStaticReferenceTypeAmbiguity.java
@@ -1,0 +1,15 @@
+class Test {
+
+  static class A {
+    void foo() {}
+    static void foo(A a, A... as) {}
+  }
+
+  interface I {
+    void bar(A a);
+  }
+
+  static void test() {
+    I i = A::<error descr="Reference to 'foo' is ambiguous, both 'foo(A, A...)' and 'foo()' match">foo</error>;
+  }
+}

--- a/java/java-tests/testSrc/com/intellij/java/codeInsight/daemon/lambda/AaaaTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/codeInsight/daemon/lambda/AaaaTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2000-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.java.codeInsight.daemon.lambda;
+
+import com.intellij.codeInsight.daemon.LightDaemonAnalyzerTestCase;
+import com.intellij.codeInspection.LocalInspectionTool;
+import com.intellij.codeInspection.deadCode.UnusedDeclarationInspection;
+import com.intellij.codeInspection.uncheckedWarnings.UncheckedWarningLocalInspection;
+import com.intellij.openapi.projectRoots.JavaSdkVersion;
+import com.intellij.testFramework.IdeaTestUtil;
+import org.jetbrains.annotations.NotNull;
+
+public class AaaaTest extends LightDaemonAnalyzerTestCase {
+  private static final String BASE_PATH = "/codeInsight/daemonCodeAnalyzer/lambda/newMethodRef/";
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    enableInspectionTool(new UnusedDeclarationInspection());
+  }
+
+  @Override
+  protected LocalInspectionTool @NotNull [] configureLocalInspectionTools() {
+    return new LocalInspectionTool[]{
+      new UncheckedWarningLocalInspection()
+    };
+  }
+
+  public void testAaaInstanceInstance() {
+    // success
+    doTest();
+  }
+
+  public void testAaaInstanceInstanceVararg() {
+    // success
+    doTest();
+  }
+  public void testAaaInstanceStatic() {
+    // success
+    doTest();
+  }
+  public void testAaaInstanceStaticVararg() {
+    // failure
+    doTest();
+  }
+  public void testAaaInstanceVarargStatic() {
+    // failure
+    doTest();
+  }
+
+  public void testAaaInstanceVarargStaticVararg() {
+    // success
+    doTest();
+  }
+
+  public void testAaaStaticStaticVararg() {
+    // success
+    doTest();
+  }
+
+  public void testAaaConfusingErrorMessageWhileIncompatibleTypes() {
+    // failure
+    doTest();
+  }
+
+  private void doTest() {
+    doTest(false);
+  }
+
+  private void doTest(boolean warnings) {
+    IdeaTestUtil.setTestVersion(JavaSdkVersion.JDK_1_8, getModule(), getTestRootDisposable());
+    doTest(BASE_PATH + getTestName(false) + ".java", warnings, false);
+  }
+}

--- a/java/java-tests/testSrc/com/intellij/java/codeInsight/daemon/lambda/NewMethodRefHighlightingTest.java
+++ b/java/java-tests/testSrc/com/intellij/java/codeInsight/daemon/lambda/NewMethodRefHighlightingTest.java
@@ -86,6 +86,8 @@ public class NewMethodRefHighlightingTest extends LightDaemonAnalyzerTestCase {
       .forEach(info -> Assert.assertEquals("<html>Reference to 'm' is ambiguous, both 'm(Test, String)' and 'm(String)' match</html>",
                                            info.getToolTip()));
   }
+  public void testStaticNonStaticWithVarargsReferenceTypeAmbiguity() { doTest(); }
+  public void testStaticWithVarargsNonStaticReferenceTypeAmbiguity() { doTest(); }
   public void testSuperClassPotentiallyApplicableMembers() { doTest(); }
   public void testExactMethodReferencePertinentToApplicabilityCheck() { doTest(); }
   public void testAmbiguityVarargs() { doTest(); }


### PR DESCRIPTION
This PR contains fixes of two problems. I combined them into one PR, as they look very similar and the second fix does not work without the first one.

### 1. Static varargs method and non-static method in match

#### How to reproduce the problem
There is ambiguous method reference `A::foo` in the following code snippet
```java
public class Main {

    static class A {
        void foo() {}
        static void foo(A a, A... as) {}
    }

    interface I {
        void bar(A a);
    }

    public static void main(String[] args) {
        I i = A::foo;
    }
}
```
Try to compile using javac 8, 11, 16
```
Main.java:13: error: incompatible types: invalid method reference
        I i = A::foo;
              ^
    reference to foo is ambiguous
      both method foo(A,A...) in A and method foo() in A match
1 error
```

#### Expected IDEA behavior
Red highlight `foo` with message
```
Reference to 'foo' is ambiguous, both 'foo(A, A...)' and 'foo()' match
```

#### Actual IDEA behavior
There is no highlight
<img width="919" alt="actual" src="https://user-images.githubusercontent.com/42293632/130364082-fb5e5c90-0cf3-480f-ba25-2cdce4f2270e.png">

Moreover, IDEA suggests to replace correct lambda with incorrect reference
<img width="717" alt="actuak1" src="https://user-images.githubusercontent.com/42293632/130364422-d8a65fd5-c9bb-4d6c-99cd-a681c8979fd0.png">

#### Why the reference is ambiguous
The method reference is ambiguous because 15.13.1 says
- If the first search produces a static method, and no non-static method is applicable during the second search, then the compile-time declaration is the result of the first search.
- Otherwise, if no static method is applicable during the first search, and the second search produces a non-static method, then the compile-time declaration is the result of the second search. 
- Otherwise, there is no compile-time declaration. 

The first search: `static foo(A, A...)`. The second search: `foo()`. Both conditions are failed so the reference is ambiguous.

#### Proposed solution
The patch adds check that one of the two conditions is true before `MethodReferenceConflictResolver#guardedOverloadResolution` returns the result.

### 2. Static method and non-static varargs  method in match

#### How to reproduce the problem
There is ambiguous method reference `A::foo` in the following code snippet
```java
public class Main {

    static class A {
        void foo(A... as) {}
        static void foo(A a) {}
    }

    interface I {
        void bar(A a);
    }

    public static void main(String[] args) {
        I i = A::foo;
    }
}
```
Try to compile using javac 8, 11, 16
```
Main.java:13: error: incompatible types: invalid method reference
        I i = A::foo;
              ^
    reference to foo is ambiguous
      both method foo(A) in A and method foo(A...) in A match
1 error
```

#### Expected IDEA behavior
Red highlight `foo` with message
```
Reference to 'foo' is ambiguous, both 'foo(A...)' and 'foo(A)' match
```

#### Actual IDEA behavior
There is no highlight
<img width="909" alt="actual2" src="https://user-images.githubusercontent.com/42293632/130367370-33e07b34-7d6b-4780-a19d-a8eebc48278c.png">

Moreover, IDEA suggests to replace correct lambda with incorrect reference
<img width="739" alt="actual3" src="https://user-images.githubusercontent.com/42293632/130367401-04fc0dfe-6776-472f-b6fa-81c8c3cf971e.png">

#### Why the reference is ambiguous
The method reference is ambiguous because 15.13.1 says
- If the first search produces a static method, and no non-static method is applicable during the second search, then the compile-time declaration is the result of the first search.
- Otherwise, if no static method is applicable during the first search, and the second search produces a non-static method, then the compile-time declaration is the result of the second search. 
- Otherwise, there is no compile-time declaration. 

The first search: `static foo(A)`. The second search: `foo(A...)`. Both conditions are failed so the reference is ambiguous.

#### Proposed solution 
Before the patch
The first search: `foo(A...)`, `static foo(A)`. The second search: `none`. It is wrong. `foo(A...)` should be in the second search because 15.3.1 says
"In the second search, if P1, ..., Pn is not empty and P1 is a subtype of ReferenceType, then the method reference expression is treated as if it were a method invocation expression with argument expressions of types P2, ..., Pn."
We can verify this by running
```
javac --debug dumpMethodReferenceSearchResults Main.java
```
<img width="615" alt="javac" src="https://user-images.githubusercontent.com/42293632/130368721-0005c8d6-19a6-4e9e-8a7a-37f44ef504ac.png">

The patch moves non-static varargs method from the first search to the second one.
